### PR TITLE
Update icalparser.py

### DIFF
--- a/icalevents/icalparser.py
+++ b/icalevents/icalparser.py
@@ -271,14 +271,16 @@ def parse_events(content, start=None, end=None, default_span=timedelta(days=7)):
     else:
         cal_tz = UTC
 
-    start = normalize(start, cal_tz)
-    end = normalize(end, cal_tz)
+    _start = normalize(start, cal_tz)
+    _end = normalize(end, cal_tz)
 
     found = []
 
     # Skip dates that are stored as exceptions.
     exceptions = {}
     for component in calendar.walk():
+        start = _start
+        end = _end
         if component.name == "VEVENT":
             e = create_event(component, cal_tz)
 


### PR DESCRIPTION
Resetting start and end date while walking the calendar. This prevents that some events are missing if there is an all_day-Event in between some events.

Consider the following settings:
  startdate: 01.12.2020 00:00:00
  enddate: 31.12.2020 23:59:59
  
  Events:
  10.12.2020 18:00:00 EventA
  22.12.2020 AllDay     EventB
  31.12.2020 17:00:00 EventC

While iterating through the calendar, the enddate-settings are reseted during the allday-event to 31.12.2020 00:00:00 and then EventC is missing in the list!