### PR TITLE
Drop datetime dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ httplib2
 icalendar
 python-dateutil >= 2.7.0
 pytz
-datetime
 coverage
 codecov

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ setup(
         "httplib2",
         "icalendar",
         "pytz",
-        "datetime",
     ],
     version=version,
     description = 'iCal downloader and parser',


### PR DESCRIPTION
Having datetime listed as a dependency leads to errors during install, since its a python lib it does not have to be listed in the requirements.txt or der the setup.py