### PR TITLE
fix: Template on empty/unreadable file exception is a string, not a float

### DIFF
--- a/icalevents/icaldownload.py
+++ b/icalevents/icaldownload.py
@@ -82,7 +82,7 @@ class ICalDownload:
             content = f.read()
 
         if not content:
-            raise IOError("File %f is not readable or is empty!" % file)
+            raise IOError("File %s is not readable or is empty!" % file)
 
         return self.decode(content, apple_fix=apple_fix)
 

--- a/test/test_icaldownload.py
+++ b/test/test_icaldownload.py
@@ -93,3 +93,14 @@ DTSTART:19180331T020000
             # Delete tmp dir
             os.chdir("..")
             shutil.rmtree("tmp")
+
+    def test_empty_file(self):
+        empty_ical = "test/test_data/empty.ics"
+
+        with self.assertRaises(IOError) as cm:
+            icalevents.icaldownload.ICalDownload().data_from_file(empty_ical)
+
+        self.assertEqual(
+            str(cm.exception),
+            "File test/test_data/empty.ics is not readable or is empty!"
+        )

--- a/test/test_icaldownload.py
+++ b/test/test_icaldownload.py
@@ -102,5 +102,5 @@ DTSTART:19180331T020000
 
         self.assertEqual(
             str(cm.exception),
-            "File test/test_data/empty.ics is not readable or is empty!"
+            "File test/test_data/empty.ics is not readable or is empty!",
         )


### PR DESCRIPTION
Tiny typo with an empty ICS file caused a TypeError exception on the library rather than the intended IOError on the file. Test case included because ... test everything :D 