### PR TITLE
mentioned required format for parse_events

### DIFF
--- a/icalevents/icalparser.py
+++ b/icalevents/icalparser.py
@@ -296,8 +296,8 @@ def parse_events(content, start=None, end=None, default_span=timedelta(days=7)):
     Query the events occurring in a given time range.
 
     :param content: iCal URL/file content as String
-    :param start: start date for search, default today
-    :param end: end date for search
+    :param start: start date for search, default today (in UTC format)
+    :param end: end date for search (in UTC format)
     :param default_span: default query length (one week)
     :return: events as list
     """


### PR DESCRIPTION
> mentioned parse_events requires the start and end dates in UTC format

`parse_events` is a cool function, I didn't expect that it would require start and end dates in UTC formats. I guess its worth mentioning it in Docs. 
I noticed certain small differences if used with dates of local time zone.
