### PR TITLE
Update documentation hint to date type

### DIFF
--- a/icalevents/icalevents.py
+++ b/icalevents/icalevents.py
@@ -27,8 +27,8 @@ def events(
     :param url: iCal URL
     :param file: iCal file path
     :param string_content: iCal content as string
-    :param start: start date (see dateutils.date)
-    :param end: end date (see dateutils.date)
+    :param start: start date (see datetime.date)
+    :param end: end date (see datetime.date)
     :param fix_apple: fix known Apple iCal issues
     :return: events as list of dictionaries
     """


### PR DESCRIPTION
I am pretty sure [`datetime`](https://docs.python.org/3/library/datetime.html#date-objects) is intended instead of [`dateutils`](https://pypi.org/project/dateutils/)