### PR TITLE
Fix ResourceWarning due to unclosed http object during download

### DIFF
--- a/icalevents/icaldownload.py
+++ b/icalevents/icaldownload.py
@@ -65,6 +65,7 @@ class ICalDownload:
             url = apple_url_fix(url)
 
         _, content = self.http.request(url)
+        self.http.close()
 
         if not content:
             raise ConnectionError("Could not get data from %s!" % url)


### PR DESCRIPTION
When running the tests, I get the following warning in the console:

```
/IdeaProjects/icalevents/icalevents/icalevents.py:82: ResourceWarning: unclosed <ssl.SSLSocket fd=3, family=2, type=1, proto=6, laddr=('172.17.0.2', 46590), raddr=('185.199.111.133', 443)>
  data += events(
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

This happens as the HTTP object isn't closed after the request. It may be closed by the garbage collector during longer runtimes, but in my opinion, it's cleaner to do it manually when the connection isn't needed anymore.