### PR TITLE
chore: Bump version number to 0.2.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ copyright = "2024, jazzband"
 author = "Martin Eigenmann"
 
 # The full version, including alpha/beta/rc tags
-release = "0.1.29"
+release = "0.2.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "icalevents"
-version = "0.1.29"
+version = "0.2.0"
 description = "Simple Python 3 library to download, parse and query iCal sources."
 authors = [
     { name = "Martin Eigenmann", email = "github@eigenmannmartin.ch" },

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from setuptools import setup
 
-version = "0.1.29"
+version = "0.2.0"
 
 setup(
     name="icalevents",


### PR DESCRIPTION
Due to the replacement of httplib2 and the requirement of icalendar >= 6.0, I bump the next version number to 0.2.0.