### PR TITLE
chore: Fix requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name="icalevents",
     packages=["icalevents"],
     install_requires=[
-        "httplib2",
+        "urllib3",
         "icalendar",
         "pytz",
         "datetime",


### PR DESCRIPTION
When replacing httplib2 with urllib3 (#154), I didn't realized I have to change the requirements there, too. This pull request fixes this little mistake.