### PR TITLE
fix: allow `string_content` to be a `str`

### DIFF
--- a/icalevents/icaldownload.py
+++ b/icalevents/icaldownload.py
@@ -100,7 +100,8 @@ class ICalDownload:
         :param apple_fix: fix Apple txdata bug
         :return: decoded (and fixed) content
         """
-        content = content.decode(encoding)
+        if isinstance(content, bytes):
+            content = content.decode(encoding)
         content = content.replace("\r", "")
 
         if apple_fix:

--- a/test/test_icalevents.py
+++ b/test/test_icalevents.py
@@ -348,26 +348,32 @@ class ICalEventsTests(unittest.TestCase):
 
     def test_string_data(self):
         ical = "test/test_data/basic.ics"
-
         with open(ical, mode="rb") as f:
-            string_content = f.read()
+            raw_data = f.read()
 
-        start = date(2017, 5, 18)
-        end = date(2017, 5, 19)
-        key = "basic"
+        for stest, string_content in [
+            ("as bytes", raw_data),
+            ("as str", raw_data.decode()),
+        ]:
+            with self.subTest(stest):
+                start = date(2017, 5, 18)
+                end = date(2017, 5, 19)
+                key = "basic"
 
-        icalevents.request_data(
-            key,
-            url=None,
-            file=None,
-            string_content=string_content,
-            start=start,
-            end=end,
-            fix_apple=False,
-        )
+                icalevents.request_data(
+                    key,
+                    url=None,
+                    file=None,
+                    string_content=string_content,
+                    start=start,
+                    end=end,
+                    fix_apple=False,
+                )
 
-        self.assertTrue(icalevents.all_done(key), "request is finished")
-        self.assertEqual(len(icalevents.latest_events(key)), 2, "two events are found")
+                self.assertTrue(icalevents.all_done(key), "request is finished")
+                self.assertEqual(
+                    len(icalevents.latest_events(key)), 2, "two events are found"
+                )
 
     def test_events_no_description(self):
         ical = "test/test_data/no_description.ics"


### PR DESCRIPTION
I was surprised to read the `events()` docstring stating:

> :param string_content: iCal content as string

... While not being able to pass a `str`. Here is the error in this case:

```python
Traceback (most recent call last):
  File "test.py", line 28, in <module>
    events = icalevents.events(
        string_content=ics,
    ...<3 lines>...
        sort=True,
    )
  File "/.../icalevents/icalevents.py", line 55, in events
    content = ical_download.data_from_string(string_content, apple_fix=fix_apple)
  File "/.../icalevents/icaldownload.py", line 91, in data_from_string
    return self.decode(string_content, apple_fix=apple_fix)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../icalevents/icaldownload.py", line 103, in decode
    content = content.decode(encoding)
              ^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'decode'. Did you mean: 'encode'?
```

So here is a small patch to allow both `bytes`, and `str`.