### PR TITLE
fix: replace usage of `IOError` with `OSError`

### DIFF
--- a/icalevents/icaldownload.py
+++ b/icalevents/icaldownload.py
@@ -80,13 +80,13 @@ class ICalDownload:
             content = f.read()
 
         if not content:
-            raise IOError("File %s is not readable or is empty!" % file)
+            raise OSError("File %s is not readable or is empty!" % file)
 
         return self.decode(content, apple_fix=apple_fix)
 
     def data_from_string(self, string_content, apple_fix=False):
         if not string_content:
-            raise IOError("String content is not readable or is empty!")
+            raise OSError("String content is not readable or is empty!")
 
         return self.decode(string_content, apple_fix=apple_fix)
 

--- a/test/test_icaldownload.py
+++ b/test/test_icaldownload.py
@@ -74,7 +74,7 @@ DTSTART:19180331T020000
     def test_empty_file(self):
         empty_ical = "test/test_data/empty.ics"
 
-        with self.assertRaises(IOError) as cm:
+        with self.assertRaises(OSError) as cm:
             icalevents.icaldownload.ICalDownload().data_from_file(empty_ical)
 
         self.assertEqual(


### PR DESCRIPTION
`IOError` was merged in `OSError` since Python 3.3 (https://docs.python.org/3/library/exceptions.html#OSError).